### PR TITLE
Fix displayName in package.json

### DIFF
--- a/Roslyn Library/Unity-artifacts/package.json
+++ b/Roslyn Library/Unity-artifacts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.abxy.roslyn",
-  "displayName": "\".NET Compiler Platform (\"Roslyn\")\"",
+  "displayName": ".NET Compiler Platform (Roslyn)",
   "version": "0.0.1",
   "unity": "2018.1",
   "description": "The Roslyn .NET compiler provides C# and Visual Basic languages with rich code analysis APIs",


### PR DESCRIPTION
The displayName in package.json cannot contain double quotes.
If I install it via UPM and select it in the project tab, I get an error.

![image](https://user-images.githubusercontent.com/1295639/83351195-d7cc8b00-a37c-11ea-90de-708ede0a0189.png)
